### PR TITLE
Allow cross origin URLs for 'panorama'

### DIFF
--- a/photo-sphere-viewer.js
+++ b/photo-sphere-viewer.js
@@ -192,6 +192,7 @@ var PhotoSphereViewer = function(args) {
 
 	var createBuffer = function(pano_data) {
 		var img = new Image();
+		img.setAttribute('crossOrigin', 'anonymous');
 
 		img.onload = function() {
 				// No XMP data?


### PR DESCRIPTION
Avoids tainted canvas on export. The even better approach would be to do full CORS.